### PR TITLE
fix(servers): fix plugin segfault when bootscript is nul

### DIFF
--- a/internal/services/instance/servers_data_source.go
+++ b/internal/services/instance/servers_data_source.go
@@ -183,7 +183,9 @@ func DataSourceInstanceServersRead(ctx context.Context, d *schema.ResourceData, 
 		rawServer["zone"] = string(zone)
 		rawServer["name"] = server.Name
 		rawServer["boot_type"] = server.BootType
-		rawServer["bootscript_id"] = server.Bootscript.ID
+		if server.Bootscript != nil {
+			rawServer["bootscript_id"] = server.Bootscript.ID
+		}
 		rawServer["type"] = server.CommercialType
 		if len(server.Tags) > 0 {
 			rawServer["tags"] = server.Tags


### PR DESCRIPTION
In https://www.scaleway.com/en/developers/api/instance/#path-instances-list-all-instances

We can see that bootscript is deprecated
![image](https://github.com/user-attachments/assets/b910b0fc-f4db-4394-8f13-5a9089feea3c)
